### PR TITLE
case-insensitive property fixed, final adjustments before deployment

### DIFF
--- a/practice-app/post/templates/post_get.html
+++ b/practice-app/post/templates/post_get.html
@@ -15,8 +15,8 @@
     <div class="wrapper">
         <div class="header">POSTS</div>
         
-        <a href="http://127.0.0.1:8000/post/">Back</a>
-        <a href="http://127.0.0.1:8000/">Go to Home Page</a>
+        <a href="../">Back</a>
+        <a href="../../">Go to Home Page</a>
         
         <div class="cards_wrap">
             {% for json in response %}

--- a/practice-app/post/views.py
+++ b/practice-app/post/views.py
@@ -83,7 +83,7 @@ def poster(req):
         #assigns country as empty string if fails
         try:
             country = req.POST['country']
-            country = re.sub("(^|\s)(\S)", convert_into_uppercase, country).replace('Of', 'of')
+            country = re.sub("(^|\s)(\S)", convert_into_uppercase, country.lower()).replace('Of', 'of')
         except:
             country = ''
 


### PR DESCRIPTION
**Done:**

- The case-insensitive country names were not working as expected. Just the first letter was changing. I fixed it. See relevant issue #135.
- The `localhost:8000` reference links are removed from the code and replaced by `../`