### PR TITLE
Login pages being on top of each other after sign-up is fixed

### DIFF
--- a/app/mobile/bounswe5_mobile/lib/screens/signup.dart
+++ b/app/mobile/bounswe5_mobile/lib/screens/signup.dart
@@ -315,10 +315,7 @@ class _SignupPageState extends State<SignupPage> {
                                   }
                                   bool registered = await register(_email.text, _pass.text, type);
                                   if (registered) { //if registered successfully, go to the login page
-                                    Navigator.pushReplacement(
-                                      context,
-                                      MaterialPageRoute(builder: (context) => const LoginPage()),
-                                    );
+                                    Navigator.pop(context);
                                   } else {
                                     ScaffoldMessenger.of(context).showSnackBar(
                                       const SnackBar(content: Text('Could not register')),


### PR DESCRIPTION
***Description*:**
A bug needed to be fixed after a user registers successfully.

***Tasks Done*:**
- After sign-up, instead of a new login page, the login page under the sign-up page is opened.

***Reviewer*:**
- @enginoguzhansenol 

***Issue*:** 
* See [Issue #277](https://github.com/bounswe/bounswe2022group5/issues/277)