### PR TITLE
[Mobile] Drawer head in the Home page is updated

### DIFF
--- a/app/mobile/bounswe5_mobile/lib/widgets/MyDrawer.dart
+++ b/app/mobile/bounswe5_mobile/lib/widgets/MyDrawer.dart
@@ -29,7 +29,7 @@ class MyDrawer extends StatelessWidget{
     // While session is active, username or name will be displayed.
     // If not, a "sign in" text is showed.
     if(isSessionActive){
-      displayName = "John";
+      displayName = activeUser!.email;
     }else{
       displayName = "Please sign in";
     }
@@ -37,71 +37,74 @@ class MyDrawer extends StatelessWidget{
       child: ListView(
         padding: EdgeInsets.zero,
         children: [
-          DrawerHeader(
-            decoration: BoxDecoration(
-              color: color,
-            ),
+          SizedBox(
+            height: 240,
+            child: DrawerHeader(
+              decoration: BoxDecoration(
+                color: color,
+              ),
 
-            child: Column(
-              children: [
-                InkWell(
-                  // Profile image
-                  child: CircleAvatar(
-                    radius: 42,
-                    backgroundImage: AssetImage(tempImagePath),
-                  ),
-                  onTap: (){
-                    // If session is active, user is directed to the profile page
-                    // when he/she click on profile image. If not, directed to the
-                    // log in page.
-                    if(isSessionActive) {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(builder: (context) =>
-                            ProfilePage(activeUser: activeUser!)),
-                      );
-                    }else{
-                      Navigator.pushReplacement(
-                        context,
-                        MaterialPageRoute(builder: (context) =>
-                            LoginPage()),
-                      );
-                    }
-
-                  },
-                ),
-                const SizedBox(height: 12),
-                InkWell(
-                  // Name displayed in the drawer
-                  child: Text(
-                    displayName,
-                    style: const TextStyle(
-                        fontSize:22.0,
-                        fontWeight: FontWeight.bold,
-                        color:Colors.white
+              child: Column(
+                children: [
+                  InkWell(
+                    // Profile image
+                    child: CircleAvatar(
+                      radius: 42,
+                      backgroundImage: AssetImage(tempImagePath),
                     ),
-                  ),
-                  onTap: (){
-                    // If session is active, user is directed to the profile page
-                    // when he/she click on his/her name. If not, directed to the
-                    // log in page
-                    if(isSessionActive) {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(builder: (context) =>
-                            ProfilePage(activeUser: activeUser!)),
-                      );
-                    }else{
-                      Navigator.pushReplacement(
-                        context,
-                        MaterialPageRoute(builder: (context) =>
-                            LoginPage()),
-                      );
-                    }
+                    onTap: (){
+                      // If session is active, user is directed to the profile page
+                      // when he/she click on profile image. If not, directed to the
+                      // log in page.
+                      if(isSessionActive) {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(builder: (context) =>
+                              ProfilePage(activeUser: activeUser!)),
+                        );
+                      }else{
+                        Navigator.pushReplacement(
+                          context,
+                          MaterialPageRoute(builder: (context) =>
+                              LoginPage()),
+                        );
+                      }
 
-                  },
-                )
-              ],
+                    },
+                  ),
+                  const SizedBox(height: 12),
+                  InkWell(
+                    // Name displayed in the drawer
+                    child: Text(
+                      displayName,
+                      style: const TextStyle(
+                          fontSize:22.0,
+                          fontWeight: FontWeight.bold,
+                          color:Colors.white
+                      ),
+                    ),
+                    onTap: (){
+                      // If session is active, user is directed to the profile page
+                      // when he/she click on his/her name. If not, directed to the
+                      // log in page
+                      if(isSessionActive) {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(builder: (context) =>
+                              ProfilePage(activeUser: activeUser!)),
+                        );
+                      }else{
+                        Navigator.pushReplacement(
+                          context,
+                          MaterialPageRoute(builder: (context) =>
+                              LoginPage()),
+                        );
+                      }
+
+                    },
+                  )
+                ],
+              ),
             ),
           ),
 


### PR DESCRIPTION
***Description*:**
To create a user specific home page, user should be able to see his/her name or username or email. For our case, since just the email is available for an user, I needed to correct drawer head in a way that it shows the email of the user.

***Tasks Done*:**
- [x] Instead of a dummy name like 'John', user can now see his/her email in drawer head in the home page.
- [x] Height of this header has been increased to prevent overflows.

***Reviewer*:** @enginoguzhansenol 

***Issue*:** 
* See [#279 ](https://github.com/bounswe/bounswe2022group5/issues/279)
