### PR TITLE
[Backend] Create post without image urls #299

### DIFF
--- a/app/backend/forum/views.py
+++ b/app/backend/forum/views.py
@@ -43,20 +43,23 @@ def create_post(request):
     post = Post(title=title, author=author, body=body, date=date)
     post.save()
 
-    image_urls = request.data['image_urls']
-    for image_url in image_urls:
-        url = PostImages(image_url=image_url, post=post)
-        url.save()
     data = {
         'title':title,
         'author': author,
         'body':body,
         'date':date
     }
-    
-    serialized_data = PostSerializer(data)
-    print(serialized_data.data)
-    return Response({'post':serialized_data.data, 'image_urls': image_urls})
 
-    
+    response_object = {}
+    response_object['post'] = PostSerializer(data).data
+
+    if 'image_urls' in request.data and len(request.data['image_urls']) > 0:
+        for image_url in request.data['image_urls']:
+            url = PostImages(image_url=image_url, post=post)
+            url.save()
+        response_object['image_urls'] = request.data['image_urls']
+    else:
+        response_object['image_urls'] = []
+
+    return Response(response_object)
 


### PR DESCRIPTION
***Description*:**

When users created posts without image urls, it caused exception in the back end.
Now fixed.

***Reviewer*:** @canberkboun9  

**Notes:** 
- Caused by code trying to access request.data['image_urls'] when it didn't exist.

***Issue*:** 
* See [Issue #299](https://github.com/bounswe/bounswe2022group5/issues/299)