### PR TITLE
[Mobile] Necessary page connections in the home page have been implemented

### DIFF
--- a/app/mobile/bounswe5_mobile/lib/API_service.dart
+++ b/app/mobile/bounswe5_mobile/lib/API_service.dart
@@ -125,7 +125,7 @@ class ApiService {
       user = User(-1, token, email, userType);
       return user;
     } else{
-      return null;
+      return User(-1, '-1', '-1', -1);
     }
 
   }

--- a/app/mobile/bounswe5_mobile/lib/main.dart
+++ b/app/mobile/bounswe5_mobile/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:bounswe5_mobile/screens/viewArticle.dart';
 import 'package:bounswe5_mobile/screens/createArticle.dart';
 import 'package:flutter/material.dart';
 import 'package:flex_color_scheme/flex_color_scheme.dart';
+import 'package:bounswe5_mobile/mockData.dart';
 
 void main() {
   runApp(const MyApp());
@@ -35,7 +36,7 @@ class MyApp extends StatelessWidget {
         // To use the playground font, add GoogleFonts package and uncomment
         // fontFamily: GoogleFonts.notoSans().fontFamily,
       ),
-      home: const LoginPage(),
+      home: LoginPage(),
     );
   }
 }

--- a/app/mobile/bounswe5_mobile/lib/screens/home.dart
+++ b/app/mobile/bounswe5_mobile/lib/screens/home.dart
@@ -6,6 +6,9 @@ import 'package:bounswe5_mobile/widgets/ArticlesList.dart';
 import 'package:bounswe5_mobile/API_service.dart';
 import 'package:bounswe5_mobile/mockData.dart';
 import 'package:bounswe5_mobile/screens/createPost.dart';
+import 'package:bounswe5_mobile/screens/createArticle.dart';
+import 'package:bounswe5_mobile/screens/viewPost.dart';
+import 'package:bounswe5_mobile/screens/viewArticle.dart';
 
 /// This is the implementation of the home page.
 class HomePage extends StatefulWidget {
@@ -25,9 +28,6 @@ class _HomePageState extends State<HomePage> {
 
     ApiService apiServer = ApiService();
 
-    /// Forum, Articles and Chatbot bodies.
-    List<Widget> bodies = [ForumList(posts: posts,), ArticlesList(articles: articles,)];
-
     return FutureBuilder<User?>(
       future: apiServer.getUserInfo(widget.token),
       builder: (context,snapshot){
@@ -38,16 +38,31 @@ class _HomePageState extends State<HomePage> {
         // we should show the home page. Until that time, a loading
         // icon is shown.
         if(snapshot.hasData || widget.token == '-1'){
+          print(snapshot.data);
+          User activeUser = snapshot.data ?? User(-1, '-1', '-1', -1);
+
+          /// Forum, Articles and Chatbot bodies.
+          List<Widget> bodies = [ForumList(activeUser: activeUser, posts: posts,), ArticlesList(articles: articles,)];
+
           // Session activity means that a registered user is entered
           // the home page.
           bool isSessionActive = widget.token != '-1';
+
+          print(isSessionActive);
 
           // Floating button that will be used to create posts/articles:
           Widget floatingButton = SizedBox.shrink();
           if(isSessionActive){
             if(currentIndex == 0){
               floatingButton = FloatingActionButton(
-                  onPressed: (){print("User create post");},
+                  onPressed: (){
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(builder: (context) =>
+                          CreatePostPage(activeUser: activeUser)),
+                    );
+                    print("User create post");
+                    },
                   backgroundColor: Theme.of(context).colorScheme.primary,
                   child: Icon(
                     Icons.create,
@@ -56,10 +71,17 @@ class _HomePageState extends State<HomePage> {
               );
             }
             else if(currentIndex == 1){
-              print(snapshot.data?.specialization);
-              if(snapshot.data?.usertype == 1){
+              print(activeUser.specialization);
+              if(activeUser.usertype == 1){
                 floatingButton = FloatingActionButton(
-                    onPressed: (){print("Doctor create article");},
+                    onPressed: (){
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(builder: (context) =>
+                            CreateArticlePage(activeUser: snapshot.data!)),
+                      );
+                      print("Doctor create article");
+                      },
                     backgroundColor: Theme.of(context).colorScheme.primary,
                     child: Icon(
                       Icons.create,

--- a/app/mobile/bounswe5_mobile/lib/screens/viewArticle.dart
+++ b/app/mobile/bounswe5_mobile/lib/screens/viewArticle.dart
@@ -4,9 +4,11 @@ import 'package:flutter/material.dart';
 import 'package:bounswe5_mobile/mockData.dart';
 import 'package:bounswe5_mobile/models/article.dart';
 import 'package:intl/intl.dart';
+import 'package:bounswe5_mobile/models/user.dart';
 
 class ViewArticlePage extends StatefulWidget {
-  const ViewArticlePage({Key? key}) : super(key: key);
+  const ViewArticlePage({Key? key, required this.article}) : super(key: key);
+  final Article article;
 
   @override
   State<ViewArticlePage> createState() => _ViewArticlePageState();
@@ -14,7 +16,6 @@ class ViewArticlePage extends StatefulWidget {
 
 class _ViewArticlePageState extends State<ViewArticlePage> {
 
-  Article article = articles[3];
   String tempImagePath = 'lib/assets/images/generic_user.jpg';
 
   final DateFormat formatter = DateFormat('dd/MM/yyyy');
@@ -22,12 +23,17 @@ class _ViewArticlePageState extends State<ViewArticlePage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Center(
-          child: Text('Logo',
+        centerTitle: true,
+        title: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          mainAxisSize: MainAxisSize.min,
+          children:[Text(
+              'Logo',
               style: TextStyle(
                 fontSize: 28.0,
                 fontWeight: FontWeight.bold,
-              )),
+              )
+          )],
         ),
         elevation: 0.0,
       ),
@@ -59,7 +65,7 @@ class _ViewArticlePageState extends State<ViewArticlePage> {
                               Icon(Icons.check),
                               SizedBox(width: 5),
                               Text(
-                                "Dr. " + article.author.fullName,
+                                "Dr. " + widget.article.author.fullName,
                                 maxLines: 2,
                               ),
                             ],
@@ -68,7 +74,7 @@ class _ViewArticlePageState extends State<ViewArticlePage> {
                             children: [
                               SizedBox(width: 5),
                               Text(
-                                "Published: " + formatter.format(article.time),
+                                "Published: " + formatter.format(widget.article.time),
                               ),
                             ],
                           ),
@@ -84,7 +90,7 @@ class _ViewArticlePageState extends State<ViewArticlePage> {
                 constraints: BoxConstraints(maxHeight: double.infinity),
                 width: double.infinity,
                 child: Text(
-                  article.header,
+                  widget.article.header,
                   maxLines: 3,
                   textAlign: TextAlign.center,
                   style: TextStyle(
@@ -101,7 +107,7 @@ class _ViewArticlePageState extends State<ViewArticlePage> {
                 constraints: BoxConstraints(maxHeight: double.infinity),
                 width: double.infinity,
                 child: Text(
-                  article.body,
+                  widget.article.body,
                   textAlign: TextAlign.left,
                   style: TextStyle(
                     color: Colors.black,
@@ -130,7 +136,7 @@ class _ViewArticlePageState extends State<ViewArticlePage> {
                         width: 10,
                       ),
                       Text(
-                        article.upvotes.toString(),
+                        widget.article.upvotes.toString(),
                         style: TextStyle(
                             color: Colors.green,
                             fontWeight: FontWeight.bold,
@@ -155,7 +161,7 @@ class _ViewArticlePageState extends State<ViewArticlePage> {
                         width: 10,
                       ),
                       Text(
-                        article.downvotes.toString(),
+                        widget.article.downvotes.toString(),
                         style: TextStyle(
                             color: Colors.red,
                             fontWeight: FontWeight.bold,

--- a/app/mobile/bounswe5_mobile/lib/screens/viewPost.dart
+++ b/app/mobile/bounswe5_mobile/lib/screens/viewPost.dart
@@ -9,15 +9,15 @@ import 'package:intl/intl.dart';
 import 'package:bounswe5_mobile/models/user.dart';
 
 class ViewPostPage extends StatefulWidget {
-  const ViewPostPage({Key? key, required User this.activeUser}) : super(key: key);
+  const ViewPostPage({Key? key, required User this.activeUser, required this.post}) : super(key: key);
   final User activeUser;
+  final Post post;
 
   @override
   State<ViewPostPage> createState() => _ViewPostPageState();
 }
 
 class _ViewPostPageState extends State<ViewPostPage> {
-  Post post = posts[1];
   String tempImagePath = 'lib/assets/images/generic_user.jpg';
 
   final DateFormat formatter = DateFormat('dd/MM/yyyy');
@@ -62,17 +62,24 @@ class _ViewPostPageState extends State<ViewPostPage> {
 
   @override
   Widget build(BuildContext context) {
+    bool isSessionActive = widget.activeUser.token != '-1';
+
     return Scaffold(
       appBar: AppBar(
-        title: const Center(
-          child: Text('Logo',
-              style: TextStyle(
-                fontSize: 28.0,
-                fontWeight: FontWeight.bold,
-              )),
-        ),
-        elevation: 0.0,
+      centerTitle: true,
+      title: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        mainAxisSize: MainAxisSize.min,
+        children:[Text(
+            'Logo',
+            style: TextStyle(
+              fontSize: 28.0,
+              fontWeight: FontWeight.bold,
+            )
+        )],
       ),
+      elevation: 0.0,
+    ),
       body: ListView(children: [
         Container(
           constraints: BoxConstraints(maxHeight: double.infinity),
@@ -100,7 +107,7 @@ class _ViewPostPageState extends State<ViewPostPage> {
                             children: [
                               SizedBox(width: 5),
                               Text(
-                                post.author.username,
+                                widget.post.author.username,
                               ),
                             ],
                           ),
@@ -108,7 +115,7 @@ class _ViewPostPageState extends State<ViewPostPage> {
                             children: [
                               SizedBox(width: 5),
                               Text(
-                                "Published: " + formatter.format(post.time),
+                                "Published: " + formatter.format(widget.post.time),
                               ),
                             ],
                           ),
@@ -126,7 +133,7 @@ class _ViewPostPageState extends State<ViewPostPage> {
                 constraints: BoxConstraints(maxHeight: double.infinity),
                 width: double.infinity,
                 child: Text(
-                  post.header,
+                  widget.post.header,
                   textAlign: TextAlign.center,
                   style: TextStyle(
                     color: Colors.black,
@@ -141,7 +148,7 @@ class _ViewPostPageState extends State<ViewPostPage> {
                 constraints: BoxConstraints(maxHeight: double.infinity),
                 width: double.infinity,
                 child: Text(
-                  post.body,
+                  widget.post.body,
                   textAlign: TextAlign.left,
                   style: TextStyle(
                     color: Colors.black,
@@ -173,7 +180,11 @@ class _ViewPostPageState extends State<ViewPostPage> {
                           children: [
                             InkWell(
                               onTap: ((){
-                                print("Post upvoted.");
+                                if(isSessionActive){
+                                  print("Post upvoted.");
+                                }
+
+
                               }),
                               child: Icon(
                                 Icons.arrow_upward,
@@ -185,7 +196,7 @@ class _ViewPostPageState extends State<ViewPostPage> {
                               width: 5,
                             ),
                             Text(
-                                post.upvotes.toString(),
+                                widget.post.upvotes.toString(),
                                 style: TextStyle(
                                     color: Colors.green,
                                     fontWeight: FontWeight.bold,
@@ -199,7 +210,11 @@ class _ViewPostPageState extends State<ViewPostPage> {
                           children: [
                             InkWell(
                               onTap: ((){
-                                print("Post downvoted.");
+                                if(isSessionActive){
+                                  print("Post downvoted.");
+                                }
+
+
                               }),
                               child: Icon(
                                 Icons.arrow_downward,
@@ -211,7 +226,7 @@ class _ViewPostPageState extends State<ViewPostPage> {
                               width: 5,
                             ),
                             Text(
-                                post.downvotes.toString(),
+                                widget.post.downvotes.toString(),
                                 style: TextStyle(
                                     color: Colors.red,
                                     fontWeight: FontWeight.bold,
@@ -235,12 +250,13 @@ class _ViewPostPageState extends State<ViewPostPage> {
                         ],
                       ),
                     ),
+                    isSessionActive ?
                     ElevatedButton(
                       onPressed: () async {
                         Navigator.push(
                           context,
                           MaterialPageRoute(
-                              builder: (context) =>  CreateCommentPage(activeUser: widget.activeUser, postID: post.id)),
+                              builder: (context) =>  CreateCommentPage(activeUser: widget.activeUser, postID: widget.post.id)),
                         );
                         setState(() {
                         }); //refresh the page so that the comment will be visible ???
@@ -256,7 +272,7 @@ class _ViewPostPageState extends State<ViewPostPage> {
                           ),
                         ],
                       ),
-                    ),
+                    ) : SizedBox.shrink(),
 
                   ],
                 ),
@@ -392,7 +408,10 @@ class _ViewPostPageState extends State<ViewPostPage> {
                                       children: [
                                         InkWell(
                                           onTap: ((){
-                                            print("Post upvoted.");
+                                            if(isSessionActive){
+                                              print("Post upvoted.");
+                                            }
+
                                           }),
                                           child: Icon(
                                             Icons.arrow_upward,
@@ -418,7 +437,10 @@ class _ViewPostPageState extends State<ViewPostPage> {
                                       children: [
                                         InkWell(
                                           onTap: ((){
-                                            print("Post downvoted.");
+                                            if(isSessionActive){
+                                              print("Comment downvoted.");
+                                            }
+
                                           }),
                                           child: Icon(
                                             Icons.arrow_downward,

--- a/app/mobile/bounswe5_mobile/lib/widgets/ArticleItem.dart
+++ b/app/mobile/bounswe5_mobile/lib/widgets/ArticleItem.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:bounswe5_mobile/models/article.dart';
 import 'package:intl/intl.dart';
+import 'package:bounswe5_mobile/screens/viewArticle.dart';
+import 'package:bounswe5_mobile/models/user.dart';
 
 class ArticleItem extends StatelessWidget{
   ArticleItem({required this.index, required this.article});
@@ -11,7 +13,15 @@ class ArticleItem extends StatelessWidget{
   @override
   Widget build(BuildContext context){
     return InkWell(
-      onTap: (){print("Article $index tapped.");},
+      onTap: (){
+        Navigator.push(
+          context,
+          MaterialPageRoute(builder: (context) =>
+              ViewArticlePage(article: article)),
+        );
+
+        print("Article $index tapped.");
+        },
       child: Container(
         margin: const EdgeInsets.fromLTRB(10, 3, 10, 3),
         padding: const EdgeInsets.symmetric(horizontal: 20.0,vertical: 5.0),

--- a/app/mobile/bounswe5_mobile/lib/widgets/ArticlesList.dart
+++ b/app/mobile/bounswe5_mobile/lib/widgets/ArticlesList.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:bounswe5_mobile/models/article.dart';
 import 'package:bounswe5_mobile/widgets/ArticleItem.dart';
+import 'package:bounswe5_mobile/models/user.dart';
 
+// Active user may be empty don't forget
 class ArticlesList extends StatelessWidget{
   ArticlesList({required this.articles});
   final List<Article> articles;

--- a/app/mobile/bounswe5_mobile/lib/widgets/ForumList.dart
+++ b/app/mobile/bounswe5_mobile/lib/widgets/ForumList.dart
@@ -2,10 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:bounswe5_mobile/models/post.dart';
 import 'package:bounswe5_mobile/widgets/ForumPostItem.dart';
 import 'package:intl/intl.dart';
+import 'package:bounswe5_mobile/models/user.dart';
 
 /// List of forum items
 class ForumList extends StatelessWidget{
-  ForumList({required this.posts});
+  ForumList({required this.activeUser, required this.posts});
+  final User activeUser;
   final List<Post> posts;
 
   @override
@@ -16,7 +18,7 @@ class ForumList extends StatelessWidget{
       itemBuilder: (BuildContext context, int index) {
         final post = posts[index];
         final DateFormat formatter = DateFormat('dd/MM/yyyy');
-        return ForumPostItem(index: index, post: post, formatter: formatter);
+        return ForumPostItem(activeUser: activeUser, index: index, post: post, formatter: formatter);
       },
       separatorBuilder: (BuildContext context, int index) => const Divider(),
     );

--- a/app/mobile/bounswe5_mobile/lib/widgets/ForumPostItem.dart
+++ b/app/mobile/bounswe5_mobile/lib/widgets/ForumPostItem.dart
@@ -1,10 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:bounswe5_mobile/models/post.dart';
 import 'package:intl/intl.dart';
+import 'package:bounswe5_mobile/screens/viewPost.dart';
+import 'package:bounswe5_mobile/models/user.dart';
 
 /// A single post item shown in the Forum.
 class ForumPostItem extends StatelessWidget{
-  ForumPostItem({required this.index, required this.post, required this.formatter});
+  ForumPostItem({required this.activeUser, required this.index, required this.post, required this.formatter});
+  final User activeUser;
   final int index;
   final Post post;
   final DateFormat formatter;
@@ -12,7 +15,14 @@ class ForumPostItem extends StatelessWidget{
   @override
   Widget build(BuildContext context){
     return InkWell(
-      onTap: (){print("$index tapped.");},
+      onTap: (){
+        Navigator.push(
+          context,
+          MaterialPageRoute(builder: (context) =>
+              ViewPostPage(activeUser: activeUser, post: post)),
+        );
+        print("$index tapped.");
+        },
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 20.0,vertical: 5.0),
         height: 120,
@@ -78,12 +88,9 @@ class ForumPostItem extends StatelessWidget{
                   children: [
                     Column(
                       children: [
-                        InkWell(
-                          onTap: (){print('upvoted $index');},
-                          child: const Icon(
-                            Icons.arrow_upward,
-                            size: 30.0,
-                          ),
+                        const Icon(
+                          Icons.arrow_upward,
+                          size: 30.0,
                         ),
                         Text(
                             post.upvotes.toString()
@@ -95,12 +102,9 @@ class ForumPostItem extends StatelessWidget{
                     ),
                     Column(
                       children: [
-                        InkWell(
-                          onTap: (){print('downvoted $index');},
-                          child: const Icon(
-                            Icons.arrow_downward,
-                            size: 30.0,
-                          ),
+                        const Icon(
+                          Icons.arrow_downward,
+                          size: 30.0,
                         ),
                         Text(
                             post.downvotes.toString()

--- a/app/mobile/bounswe5_mobile/lib/widgets/MyDrawer.dart
+++ b/app/mobile/bounswe5_mobile/lib/widgets/MyDrawer.dart
@@ -22,7 +22,7 @@ class MyDrawer extends StatelessWidget{
   String tempImagePath = 'lib/assets/images/generic_user.jpg';
   @override
   Widget build(BuildContext context){
-    bool isSessionActive = activeUser != null;
+    bool isSessionActive = activeUser!.token != '-1';
     String displayName;
 
     // While session is active, username or name will be displayed.


### PR DESCRIPTION
***Description*:**
From home page, there was no connection to post/article reading/creation pages. I have implemented these connections. 

***Tasks Done*:**
- [x] Article reading page has been connected to the home page (via separate article item widgets).
- [x] Post reading page has been connected to the home page (via separate post item widgets).
    - [x] Comment creation is now specific to logged in users.
- [x] Article creation page has been connected to the home page (via floating action button).
- [x] Post creation page has been connected to the home page (via floating action button).

***Reviewer*:**
@kardelendemiral 

**Notes:** 
- From the home page, user instance can be sent to every connected page, no need to make an API call to get user info from these pages.
- From now on, API connections should be implemented.
- API function that is called when the home page is called should be redesigned. It is now returning only user data, but we need posts and articles also. This change will affect this button also since `snapshot.data` is designed in a way that it only has User info right now.

***Issue*:** 
* See [#342](https://github.com/bounswe/bounswe2022group5/issues/342)