### PR TITLE
[Mobile] Updating post page after new comment

### DIFF
--- a/app/mobile/bounswe5_mobile/lib/screens/createComment.dart
+++ b/app/mobile/bounswe5_mobile/lib/screens/createComment.dart
@@ -1,3 +1,4 @@
+import 'package:bounswe5_mobile/screens/viewPost.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
@@ -8,13 +9,14 @@ import 'package:geolocator/geolocator.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:bounswe5_mobile/API_service.dart';
 import 'package:bounswe5_mobile/models/user.dart';
+import 'package:bounswe5_mobile/models/post.dart';
 
 const List<String> categories = <String>['Anatomical Pathology', 'Anesthesiology','Cardiology','Hematology', 'Cardiovascular & Thoracic Surgery', 'Clinical Immunology/Allergy', 'Critical Care Medicine'];
 
 class CreateCommentPage extends StatefulWidget {
-  const CreateCommentPage({Key? key, required User this.activeUser, required int this.postID}) : super(key: key);
+  const CreateCommentPage({Key? key, required User this.activeUser, required Post this.post}) : super(key: key);
   final User activeUser;
-  final int postID;
+  final Post post;
   @override
   State<CreateCommentPage> createState() => _CreateCommentPageState();
 }
@@ -88,7 +90,7 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
 
   @override
   Widget build(BuildContext context) {
-
+    int postID = widget.post.id;
     ApiService apiServer = ApiService();
     return  FutureBuilder<User?>(
         future: apiServer.getUserInfo(widget.activeUser.token),
@@ -228,9 +230,16 @@ class _CreateCommentPageState extends State<CreateCommentPage> {
                                                   if(image != null){
                                                     image_uri = "${image!.uri}";
                                                   }
-                                                  int commented = await comment(widget.postID, token, _body.text, longitude, latitude, image_uri);
+                                                  int commented = await comment(postID, token, _body.text, longitude, latitude, image_uri);
                                                   if (commented == 200) {
                                                     Navigator.pop(context);
+                                                    Navigator.pushReplacement(
+                                                        context,
+                                                        MaterialPageRoute(
+                                                            builder: (context) => ViewPostPage(activeUser: widget.activeUser, post:widget.post)
+                                                        )
+                                                    );
+
                                                   } else {
                                                     ScaffoldMessenger.of(context).showSnackBar(
                                                       SnackBar(content: Text("Could not comment ${commented}")),

--- a/app/mobile/bounswe5_mobile/lib/screens/viewPost.dart
+++ b/app/mobile/bounswe5_mobile/lib/screens/viewPost.dart
@@ -335,7 +335,7 @@ class _ViewPostPageState extends State<ViewPostPage> {
                                 MaterialPageRoute(
                                     builder: (context) => CreateCommentPage(
                                         activeUser: widget.activeUser,
-                                        postID: post.id)),
+                                        post: post)),
                               );
                               setState(
                                       () {}); //refresh the page so that the comment will be visible ???


### PR DESCRIPTION
***Description*:**

Post page is updated after comment creation.

***Tasks Done*:**
- [x] Update forum page after post creation has been done in #419 by @kardelendemiral.
- [x] Update articles page after article creation has been done in #419 by @kardelendemiral.
- [x] Update post page after comment creation has been done in this PR.

***Reviewer*:** @kardelendemiral 
***Notes***
- After a comment creation, comment creation and old post page is popped and then new post page is pushed. This creates a kind of imperfect navigation animation. This can be handled in later PRs.

***Issue:*** 
- See https://github.com/bounswe/bounswe2022group5/issues/411