### PR TITLE
[Backend] Fetching Upvoted Articles and Post by User Id

### DIFF
--- a/app/backend/articles/views.py
+++ b/app/backend/articles/views.py
@@ -191,6 +191,7 @@ def get_articles_of_doctor(request, user_id):
             response.append(serializer_article_data)
 
     result_page = paginator.paginate_queryset(response, request)
+
     return paginator.get_paginated_response(result_page)
 
 @api_view(['GET', 'POST', 'DELETE'])

--- a/app/backend/articles/views.py
+++ b/app/backend/articles/views.py
@@ -143,12 +143,51 @@ def get_articles_of_doctor(request, user_id):
             else:
                 serializer_article_data['vote'] = None
             serializer_article_data['id'] = article.id
+
+            if author.type == 1:
+                doctor_data = Doctor.objects.get(user=author)
+                author_data = {
+                    'id': author.id,
+                    'username': doctor_data.full_name,
+                    'profile_photo': doctor_data.profile_picture,
+                    'is_doctor': True
+                }
+
+            elif author.type == 2:
+                member_data = Member.objects.get(user=author)
+                author_data = {
+                    'id': author.id,
+                    'username': member_data.member_username,
+                    'profile_photo': f"https://api.multiavatar.com/{member_data.info.avatar}.svg?apikey={os.getenv('AVATAR')}",
+                    'is_doctor': False
+                }
+            serializer_article_data['author'] = author_data
             response.append(serializer_article_data)
     else:
         for article in articles:
             serializer_article_data = ArticleSerializer(article).data
             serializer_article_data['vote'] = None
             serializer_article_data['id'] = article.id
+
+            if author.type == 1:
+                doctor_data = Doctor.objects.get(user=author)
+                author_data = {
+                    'id': author.id,
+                    'username': doctor_data.full_name,
+                    'profile_photo': doctor_data.profile_picture,
+                    'is_doctor': True
+                }
+
+            elif author.type == 2:
+                member_data = Member.objects.get(user=author)
+                author_data = {
+                    'id': author.id,
+                    'username': member_data.member_username,
+                    'profile_photo': f"https://api.multiavatar.com/{member_data.info.avatar}.svg?apikey={os.getenv('AVATAR')}",
+                    'is_doctor': False
+                }
+            serializer_article_data['author'] = author_data
+
             response.append(serializer_article_data)
 
     result_page = paginator.paginate_queryset(response, request)

--- a/app/backend/forum/views.py
+++ b/app/backend/forum/views.py
@@ -181,6 +181,24 @@ def get_posts_of_user(request, user_id):
         else:
             post_dict['bookmark'] = False
 
+        if author.type == 1:
+            doctor_data = Doctor.objects.get(user=author)
+            author_data = {
+                'id': author.id,
+                'username': doctor_data.full_name,
+                'profile_photo': doctor_data.profile_picture,
+                'is_doctor': True
+            }
+
+        elif author.type == 2:
+            member_data = Member.objects.get(user=author)
+            author_data = {
+                'id': author.id,
+                'username': member_data.member_username,
+                'profile_photo': f"https://api.multiavatar.com/{member_data.info.avatar}.svg?apikey={os.getenv('AVATAR')}",
+                'is_doctor': False
+            }
+        post_dict['author'] = author_data
         response_dict.append(post_dict)
 
     result_page = paginator.paginate_queryset(response_dict, request)
@@ -270,6 +288,26 @@ def get_comments_of_user(request, user_id):
             comment_dict['vote'] = 'downvote'
         else:
             comment_dict['vote'] = None
+
+
+        if author.type == 1:
+            doctor_data = Doctor.objects.get(user=author)
+            author_data = {
+                'id': author.id,
+                'username': doctor_data.full_name,
+                'profile_photo': doctor_data.profile_picture,
+                'is_doctor': True
+            }
+
+        elif author.type == 2:
+            member_data = Member.objects.get(user=author)
+            author_data = {
+                'id': author.id,
+                'username': member_data.member_username,
+                'profile_photo': f"https://api.multiavatar.com/{member_data.info.avatar}.svg?apikey={os.getenv('AVATAR')}",
+                'is_doctor': False
+            }
+        comment_dict['author'] = author_data
         response_dict.append(comment_dict)
 
     result_page = paginator.paginate_queryset(response_dict, request)

--- a/app/backend/user_profile/tests.py
+++ b/app/backend/user_profile/tests.py
@@ -79,3 +79,29 @@ class UserProfileTestCase(TestCase):
         response2 = client.get(f'/profile/bookmarked_posts', content_type="application/json",
                                 **{"HTTP_AUTHORIZATION": f"Token {token.key}"})
         self.assertEqual(response2.status_code, 200)
+
+    def test_get_upvoted_posts(self):
+        client = Client
+        user = backendModels.CustomUser.objects.create_user(email="joedoetest@gmail.com", password="testpassword",
+                                                            type=2, date_of_birth=datetime.now())
+        token = Token.objects.create(user=user)
+        post = models.Post.objects.create(title='test post title', body='test post body', author=user,
+                                          date=datetime.now())
+        response1 = client.post(f'/forum/post/{post.id}/upvote', content_type="application/json",
+                              **{"HTTP_AUTHORIZATION": f"Token {token.key}"})
+        response2 = client.get(f'/profile/upvoted_posts?page=1&page_size=10&sort=desc&user_id={user.id}', content_type="application/json",
+                               **{"HTTP_AUTHORIZATION": f"Token {token.key}"})
+        self.assertEqual(response2.status_code, 200)
+
+    def test_get_upvoted_articles(self):
+        client = Client
+        user = backendModels.CustomUser.objects.create_user(email="joedoetest@gmail.com", password="testpassword",
+                                                            type=2, date_of_birth=datetime.now())
+        token = Token.objects.create(user=user)
+        article = models.Article.objects.create(title='test post title', body='test post body', author=user,
+                                          date=datetime.now())
+        response1 = client.post(f'/articles/articles/{article.id}/upvote', content_type="application/json",
+                              **{"HTTP_AUTHORIZATION": f"Token {token.key}"})
+        response2 = client.get(f'/profile/upvoted_articles?page=1&page_size=10&sort=desc&user_id={user.id}', content_type="application/json",
+                               **{"HTTP_AUTHORIZATION": f"Token {token.key}"})
+        self.assertEqual(response2.status_code, 200)

--- a/app/backend/user_profile/views.py
+++ b/app/backend/user_profile/views.py
@@ -1,4 +1,5 @@
 import os
+from typing import Optional
 
 from rest_framework.decorators import api_view, permission_classes, authentication_classes
 from rest_framework.permissions import IsAuthenticated, AllowAny
@@ -86,7 +87,11 @@ def get_upvoted_articles(request):
     paginator.page_size = request.GET.get('page_size', 10)
     paginator.page = request.GET.get('page', 1)
 
-    upvoter = request.user
+    user_id = request.GET.get('user_id', None)
+    if user_id:
+        upvoter = CustomUser.objects.get(id = user_id)
+    else:
+        upvoter = request.user
 
     upvoted_articles = upvoter.upvoted_articles
     articles = Article.objects.filter(id__in=upvoted_articles)
@@ -146,7 +151,13 @@ def get_upvoted_posts(request):
     paginator.max_page_size = 10
     paginator.page_size = request.GET.get('page_size', 10)
     paginator.page = request.GET.get('page', 1)
-    upvoter = request.user
+
+    user_id = request.GET.get('user_id', None)
+    if user_id:
+        upvoter = CustomUser.objects.get(id = user_id)
+    else:
+        upvoter = request.user
+
     upvoted_posts = upvoter.upvoted_posts
 
     posts = Post.objects.filter(id__in=upvoted_posts)


### PR DESCRIPTION
***Description*:**
- APIs that give Upvoted Articles and Posts as response work with token and naturally user_id can not be used. Doctor profile pages are implementing now and this data should be fetched.
- User id added to endpoints. When user_id is given upvoted articles or posts of this user will be in response, otherwise upvoted articles or posts of user requested will be in response.
- Author schema added to `get_comments_of_user`, `get_posts_of_user` and `get_articles_of_user` endpoints instead of author_id.
- See #467 

***Tasks Done*:**
- [x] Add user_id parameter to Upvoted Articles API.
- [x] Add user_id parameter to Upvoted Posts API.
- [x] Update Tests.
- [x] Author Schema revised.

***Notes*:**
- After this PR, Upvoted Posts and Upvoted Articles endpoints can consume `user_id` in query parameters to fetch upvoted posts or articles of a certain user.

***Reviewer*:** @oguzhandemirelx    

***Task Deadline*:** 24.12.2022 12:00
***Review Deadline*:** 24.12.2022 18:00