### PR TITLE
[Frontend] Ontology suggestion labels and UI fix

### DIFF
--- a/app/frontend/src/components/Popup/Popup.css
+++ b/app/frontend/src/components/Popup/Popup.css
@@ -25,6 +25,6 @@
 
 .popup-inner .close-btn{
     position: absolute;
-    top: 160px;
+    bottom: 20px;
     right: 10px;
 }

--- a/app/frontend/src/layouts/HomePage/HomePage.css
+++ b/app/frontend/src/layouts/HomePage/HomePage.css
@@ -44,7 +44,7 @@
 .categories {
     display: block;
     height: 54vh;
-    width: 18vw;
+    width: 20vw;
     margin-top: 2vh;
     margin-left: 3vw;
     padding-top: 1vh;

--- a/app/frontend/src/layouts/HomePage/HomePage.js
+++ b/app/frontend/src/layouts/HomePage/HomePage.js
@@ -30,7 +30,7 @@ const buttonStyleUnclicked = {
 }
 
 const categoryButtonsStyle = {
-    width: "75%",
+    width: "70%",
     borderRadius: "4px",
     backgroundColor: 'rgb(173,216,230)',
     marginTop: "2%",
@@ -39,7 +39,7 @@ const categoryButtonsStyle = {
 }
 
 const categoryFollowStyle = {
-    width: "20%",
+    width: "25%",
     borderRadius: "4px",
     backgroundColor: '#1890ff',
     color: 'rgb(255,255,255)',
@@ -49,7 +49,7 @@ const categoryFollowStyle = {
 }
 
 const categoryUnfollowStyle = {
-    width: "20%",
+    width: "25%",
     borderRadius: "4px",
     backgroundColor: 'rgb(255,255,255)',
     color: '#1890ff',

--- a/app/frontend/src/pages/Post/Post.js
+++ b/app/frontend/src/pages/Post/Post.js
@@ -231,25 +231,28 @@ const Post = () => {
                          
                         <div>
                             <div>
-                            {'Labels:   '}  
-                            
-                            {
-                                // labelsArray.map((item, index) => (
-                                colours.map((item, index) => (
-                                    <Tag onClick={() => navigate(`/search/${item}`)} color={colours[index%colours.length]}>{item}</Tag>
-                                ))
-                            }
+                                {post?.labels ?'Labels:   ':<></>}  
+                                
+                                {
+                                    // labelsArray.map((item, index) => (
+                                    post?.labels?.map((item, index) => (
+                                        // <Tag onClick={() => navigate(`/search/${item.name}`)} color={colours[index%colours.length]}>{item.name}</Tag>
+                                        <Tag onClick={() =>  window.location.href=`https://en.wikipedia.org/wiki/${item.name}`} color={colours[index%colours.length]}>{item.name}</Tag>
+                                    ))
+                                }
                             </div>   
                             
                             <div>
-                            {'Our Suggestions:   '}  
+                                {post?.related_labels ?'Our Suggestions:   ':<></>}
+                             
                             
-                            {
-                                // labelsArray.map((item, index) => (
-                                colours.map((item, index) => (
-                                    <Tag onClick={() => navigate(`/search/${item}`)} color={colours[index%colours.length]}>{item}</Tag>
-                                ))
-                            }
+                                {
+                                    // labelsArray.map((item, index) => (
+                                    post?.related_labels?.map((item, index) => (
+                                        // <Tag onClick={() => navigate(`/search/${item}`)} color={colours[index%colours.length]}>{item}</Tag>
+                                        <Tag onClick={() =>  window.location.href=`https://en.wikipedia.org/wiki/${item}`} color={colours[index%colours.length]}>{item}</Tag>
+                                    ))
+                                }
                             </div>
                             <br></br> 
                             

--- a/app/frontend/src/pages/Post/Post.js
+++ b/app/frontend/src/pages/Post/Post.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from "react";
 import { useParams, useNavigate } from 'react-router-dom';
-import { Image, notification } from 'antd';
+import { Image, notification, Tag } from 'antd';
 import { useSelector} from 'react-redux';
 import moment from "moment";
 import {
@@ -203,7 +203,8 @@ const Post = () => {
         }
         
     }
-
+    
+    const colours = ["magenta","red","volcano","orange","gold","lime","green","cyan","blue","geekblue","purple"];
     return(<>
         <div className="discussion-logo" onClick={() => navigate("/")}>
             <Image src={logo} preview={false}/>
@@ -226,6 +227,46 @@ const Post = () => {
                             </div>
                             <div className="discussion-date">{moment(post?.date).format("DD.MM.YYYY")}</div>
                         </div>
+
+                         
+                        <div>
+                            <div>
+                            {'Labels:   '}  
+                            
+                            {
+                                // labelsArray.map((item, index) => (
+                                colours.map((item, index) => (
+                                    <Tag onClick={() => navigate(`/search/${item}`)} color={colours[index%colours.length]}>{item}</Tag>
+                                ))
+                            }
+                            </div>   
+                            
+                            <div>
+                            {'Our Suggestions:   '}  
+                            
+                            {
+                                // labelsArray.map((item, index) => (
+                                colours.map((item, index) => (
+                                    <Tag onClick={() => navigate(`/search/${item}`)} color={colours[index%colours.length]}>{item}</Tag>
+                                ))
+                            }
+                            </div>
+                            <br></br> 
+                            
+                        </div>
+
+                        {/* <div>
+                            {'Our Suggestions:   '}  
+                            
+                            {
+                                // labelsArray.map((item, index) => (
+                                colours.map((item, index) => (
+                                    <Tag color={colours[index%colours.length]}>{item}</Tag>
+                                ))
+                            }
+                        </div> */}
+                            
+
                         <div className="discussion-body-votes">
                             <div dangerouslySetInnerHTML={{ __html: post?.body }} ref={el => {
                                 textRef.current = el;


### PR DESCRIPTION
***Description*:**

- The suggested labels are attached to posts and displayed on the post pages.
- Redirection of labels is handled.
- Two UI improvements were added as described below in the last two elements.

***Tasks Done*:**
- [x] Retrieved the labels of the post and related labels from the backend.
- [x]  Displayed labels and related labels in different sections.
- [x] Made them navigatable to the related Wikipedia pages.
- [x] The close button on the popups was not aligned in a good manner, I changed the position of the close button.
- [x] Follow and Unfollow buttons size adjustment made. 


***Reviewer*:** @Keremgunduz7         

***Issue*:**  [Issue Link](https://github.com/bounswe/bounswe2022group5/issues/483)
Closes #483.

