### PR TITLE
[Mobile] Bug Fix in Chatbot

### DIFF
--- a/app/mobile/bounswe5_mobile/lib/screens/chatbotScreen.dart
+++ b/app/mobile/bounswe5_mobile/lib/screens/chatbotScreen.dart
@@ -20,7 +20,7 @@ class ChatbotScreen extends StatelessWidget {
           onPressed: () async {
             try {
               dynamic conversationObject = {
-                'appId': '35f067c7290c8f7f05b2575bf22b44440',
+                'appId': '36bebeb26be6f2b3c682780b23162e51c',
                 'isSingleConversation' : false
               };
               dynamic result = await KommunicateFlutterPlugin.buildConversation(conversationObject);


### PR DESCRIPTION
***Description*:**
A chatbot for mobile is created. The AppID of the Chatbot variable is changed to the Mobile Chatbot. Since Chatbot response can only return to an URL, redirecting to the relative category cannot be done for mobile.

***Todo's*:**
- [X] Creating a special chatbot for Mobile.
- [ ] Directing the user to the relative category after final response

***Reviewer*:** @palahb       

***Issue*:** 
Closes #529.